### PR TITLE
feat: build reading practice module

### DIFF
--- a/src/app/reading/page.tsx
+++ b/src/app/reading/page.tsx
@@ -1,25 +1,5 @@
-import { BookOpenText } from "lucide-react";
-
-import { PageContainer } from "@/components/layout/page-container";
+import { ReadingPractice } from "@/components/reading/reading-practice";
 
 export default function ReadingPage() {
-  return (
-    <PageContainer
-      eyebrow="Latihan Membaca"
-      title="Baca kalimat pendek"
-      description="Latihan mendengar, membaca, dan memilih jawaban akan kita bangun di Issue #6."
-    >
-      <section className="rounded-[2rem] border border-orange-100 bg-white/85 p-6 shadow-sm shadow-orange-100/70">
-        <div className="mb-5 flex size-16 items-center justify-center rounded-[2rem] bg-sky-100 text-sky-700">
-          <BookOpenText className="size-8" aria-hidden="true" />
-        </div>
-        <p className="text-2xl font-bold leading-relaxed text-foreground">
-          Ibu membaca buku.
-        </p>
-        <p className="mt-4 text-lg text-muted-foreground">
-          Placeholder halaman latihan membaca.
-        </p>
-      </section>
-    </PageContainer>
-  );
+  return <ReadingPractice />;
 }

--- a/src/components/reading/reading-footer-actions.tsx
+++ b/src/components/reading/reading-footer-actions.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import { ArrowRight, RotateCcw } from "lucide-react";
+
+type ReadingFooterActionsProps = {
+  canContinue: boolean;
+  onRetry: () => void;
+  onContinue: () => void;
+};
+
+export function ReadingFooterActions({
+  canContinue,
+  onRetry,
+  onContinue,
+}: ReadingFooterActionsProps) {
+  return (
+    <section className="rounded-[2.25rem] border border-[#e7dbcc] bg-[#f5efe7] p-4 shadow-sm">
+      <div className="grid grid-cols-2 gap-3">
+        <button
+          type="button"
+          onClick={onRetry}
+          className="flex min-h-[88px] flex-col items-center justify-center rounded-[1.75rem] text-zinc-500 transition hover:bg-[#ece5dc] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-amber-300/70"
+        >
+          <RotateCcw className="size-6" aria-hidden="true" />
+          <span className="mt-2 text-xl font-medium">Ulangi</span>
+        </button>
+
+        <button
+          type="button"
+          onClick={onContinue}
+          disabled={!canContinue}
+          className="flex min-h-[88px] flex-col items-center justify-center rounded-full bg-gradient-to-r from-amber-700 to-orange-400 px-5 text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-amber-300/70 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          <ArrowRight className="size-6" aria-hidden="true" />
+          <span className="mt-2 text-xl font-bold">Lanjut</span>
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/src/components/reading/reading-practice.tsx
+++ b/src/components/reading/reading-practice.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { FeedbackMessage } from "@/components/ui/feedback-message";
+import { readingExercises } from "@/lib/data/reading-exercises";
+import { useSpeech } from "@/lib/hooks/use-speech";
+import { useLearningStore } from "@/lib/store/learning-store";
+import { ReadingFooterActions } from "./reading-footer-actions";
+import { ReadingProgressHeader } from "./reading-progress-header";
+import { ReadingQuestionCard } from "./reading-question-card";
+import { ReadingStageCard } from "./reading-stage-card";
+
+type FeedbackState = "idle" | "correct" | "incorrect";
+
+function getWrappedIndex(index: number, total: number) {
+  if (index < 0) {
+    return total - 1;
+  }
+
+  if (index >= total) {
+    return 0;
+  }
+
+  return index;
+}
+
+function getLevel(completedCount: number) {
+  return Math.min(5, Math.floor(completedCount / 2) + 1);
+}
+
+export function ReadingPractice() {
+  const { state, isHydrated, completeReadingExercise } = useLearningStore();
+  const { speak, isSpeaking } = useSpeech();
+
+  const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
+  const [selectedOption, setSelectedOption] = useState<string | null>(null);
+  const [feedback, setFeedback] = useState<FeedbackState>("idle");
+
+  const firstIncompleteIndex = useMemo(() => {
+    if (!isHydrated) {
+      return 0;
+    }
+
+    const incompleteIndex = readingExercises.findIndex(
+      (item) => !state.completedReadingIds.includes(item.id),
+    );
+
+    return incompleteIndex >= 0 ? incompleteIndex : 0;
+  }, [isHydrated, state.completedReadingIds]);
+
+  const currentIndex = selectedIndex ?? firstIncompleteIndex;
+  const currentExercise = readingExercises[currentIndex];
+  const completedCount = state.completedReadingIds.length;
+  const level = getLevel(completedCount);
+
+  const handleListen = useCallback(() => {
+    speak(currentExercise.speechText, {
+      lang: "id-ID",
+      rate: 0.8,
+      pitch: 1,
+    });
+  }, [currentExercise.speechText, speak]);
+
+  const handleSelectOption = useCallback(
+    (option: string) => {
+      setSelectedOption(option);
+
+      if (option === currentExercise.answer) {
+        setFeedback("correct");
+        completeReadingExercise(currentExercise.id);
+      } else {
+        setFeedback("incorrect");
+      }
+    },
+    [completeReadingExercise, currentExercise.answer, currentExercise.id],
+  );
+
+  const handleRetry = useCallback(() => {
+    setSelectedOption(null);
+    setFeedback("idle");
+    handleListen();
+  }, [handleListen]);
+
+  const handleContinue = useCallback(() => {
+    const nextIndex = getWrappedIndex(
+      currentIndex + 1,
+      readingExercises.length,
+    );
+
+    setSelectedIndex(nextIndex);
+    setSelectedOption(null);
+    setFeedback("idle");
+  }, [currentIndex]);
+
+  useEffect(() => {
+    if (!isHydrated || !state.settings.autoAudio) {
+      return;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      handleListen();
+    }, 300);
+
+    return () => {
+      window.clearTimeout(timeoutId);
+    };
+  }, [currentExercise.id, handleListen, isHydrated, state.settings.autoAudio]);
+
+  return (
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-6 xl:max-w-6xl">
+      <ReadingProgressHeader
+        completedCount={completedCount}
+        totalCount={readingExercises.length}
+        level={level}
+      />
+
+      <div className="grid gap-6 xl:grid-cols-[1.05fr_0.95fr] xl:items-start">
+        <ReadingStageCard
+          words={currentExercise.words}
+          imageEmoji={currentExercise.imageEmoji}
+          imageLabel={currentExercise.imageLabel}
+          onListen={handleListen}
+          isSpeaking={isSpeaking}
+        />
+
+        <div className="space-y-5">
+          <ReadingQuestionCard
+            question={currentExercise.question}
+            answer={currentExercise.answer}
+            options={currentExercise.options}
+            selectedOption={selectedOption}
+            feedback={feedback}
+            onSelect={handleSelectOption}
+          />
+
+          {feedback === "correct" ? (
+            <FeedbackMessage
+              variant="success"
+              title="Hebat!"
+              description="Jawabanmu benar. Yuk lanjut ke soal berikutnya."
+            />
+          ) : null}
+
+          {feedback === "incorrect" ? (
+            <FeedbackMessage
+              variant="gentle"
+              title="Belum tepat"
+              description="Tidak apa-apa. Dengarkan lagi lalu coba pelan-pelan."
+            />
+          ) : null}
+        </div>
+      </div>
+
+      <ReadingFooterActions
+        canContinue={feedback === "correct"}
+        onRetry={handleRetry}
+        onContinue={handleContinue}
+      />
+    </div>
+  );
+}

--- a/src/components/reading/reading-progress-header.tsx
+++ b/src/components/reading/reading-progress-header.tsx
@@ -1,0 +1,68 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
+
+type ReadingProgressHeaderProps = {
+  completedCount: number;
+  totalCount: number;
+  level: number;
+};
+
+export function ReadingProgressHeader({
+  completedCount,
+  totalCount,
+  level,
+}: ReadingProgressHeaderProps) {
+  const percentage =
+    totalCount > 0 ? Math.round((completedCount / totalCount) * 100) : 0;
+
+  return (
+    <section className="flex flex-col gap-5">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex items-start gap-3">
+          <Link
+            href="/"
+            className="mt-1 flex size-10 shrink-0 items-center justify-center rounded-full text-amber-800 transition hover:bg-orange-100 focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-amber-300/70"
+            aria-label="Kembali ke beranda"
+          >
+            <ArrowLeft className="size-5" aria-hidden="true" />
+          </Link>
+
+          <div>
+            <h1 className="text-3xl font-extrabold leading-tight tracking-tight text-amber-900 sm:text-4xl">
+              Latihan
+              <br />
+              Membaca
+            </h1>
+          </div>
+        </div>
+
+        <div className="inline-flex min-h-[48px] items-center rounded-full bg-[#e7e2db] px-5 text-xl font-bold text-amber-800 shadow-sm">
+          Level {level}
+        </div>
+      </div>
+
+      <div>
+        <div className="mb-3 flex items-center justify-between gap-3 text-lg font-semibold">
+          <p className="text-zinc-500">Progres Belajar</p>
+          <p className="text-amber-900">
+            {completedCount}/{totalCount} soal
+          </p>
+        </div>
+
+        <div
+          className="h-4 overflow-hidden rounded-full bg-stone-300"
+          role="progressbar"
+          aria-label="Progres latihan membaca"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={percentage}
+        >
+          <div
+            className="h-full rounded-full bg-gradient-to-r from-amber-700 to-orange-400"
+            style={{ width: `${percentage}%` }}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/reading/reading-question-card.tsx
+++ b/src/components/reading/reading-question-card.tsx
@@ -1,0 +1,66 @@
+import { Check } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+type ReadingQuestionCardProps = {
+  question: string;
+  answer: string;
+  options: [string, string];
+  selectedOption: string | null;
+  feedback: "idle" | "correct" | "incorrect";
+  onSelect: (option: string) => void;
+};
+
+export function ReadingQuestionCard({
+  question,
+  answer,
+  options,
+  selectedOption,
+  feedback,
+  onSelect,
+}: ReadingQuestionCardProps) {
+  return (
+    <section className="space-y-5">
+      <h2 className="text-center text-[2rem] font-extrabold leading-tight tracking-tight text-zinc-800 sm:text-[2.35rem] lg:text-left">
+        Mana kata <span className="text-amber-800">&quot;{answer}&quot;</span>?
+      </h2>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {options.map((option) => {
+          const isSelected = selectedOption === option;
+          const isCorrect = option === answer;
+          const showCorrectStyle = feedback === "correct" && isCorrect;
+          const showIncorrectStyle =
+            feedback === "incorrect" && isSelected && !isCorrect;
+
+          return (
+            <button
+              key={option}
+              type="button"
+              onClick={() => onSelect(option)}
+              className={cn(
+                "relative flex min-h-[108px] items-center justify-center rounded-[2rem] border-2 px-6 text-center text-[2rem] font-extrabold lowercase shadow-sm transition focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-amber-300/70",
+                "motion-reduce:transition-none",
+                showCorrectStyle
+                  ? "border-green-700 bg-[#dfe6d8] text-green-800"
+                  : showIncorrectStyle
+                    ? "border-amber-400 bg-amber-50 text-amber-800"
+                    : "border-transparent bg-white text-zinc-500 hover:border-stone-300",
+              )}
+              aria-pressed={isSelected}
+              aria-label={`${question} ${option}`}
+            >
+              {showCorrectStyle ? (
+                <span className="absolute -right-2 -top-2 flex size-10 items-center justify-center rounded-full bg-green-700 text-white shadow-sm">
+                  <Check className="size-5" aria-hidden="true" />
+                </span>
+              ) : null}
+
+              <span>{option}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/src/components/reading/reading-stage-card.tsx
+++ b/src/components/reading/reading-stage-card.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { Volume2 } from "lucide-react";
+import { motion } from "framer-motion";
+
+type ReadingStageCardProps = {
+  words: [string, string];
+  imageEmoji: string;
+  imageLabel: string;
+  onListen: () => void;
+  isSpeaking: boolean;
+};
+
+export function ReadingStageCard({
+  words,
+  imageEmoji,
+  imageLabel,
+  onListen,
+  isSpeaking,
+}: ReadingStageCardProps) {
+  return (
+    <section className="rounded-[2.75rem] bg-[#f1eee8] p-4 shadow-sm sm:p-6">
+      <div className="grid gap-4 sm:grid-cols-2">
+        {words.map((word) => (
+          <div
+            key={word}
+            className="flex min-h-[92px] items-center justify-center rounded-[2rem] bg-white px-6 text-center text-4xl font-extrabold tracking-wide text-amber-800 shadow-sm sm:min-h-[110px] sm:text-5xl"
+          >
+            {word}
+          </div>
+        ))}
+      </div>
+
+      <div className="mt-8 flex justify-center">
+        <div className="flex aspect-square w-full max-w-[240px] items-center justify-center rounded-[2rem] bg-[#ece8e1] p-4 sm:max-w-[280px]">
+          <div className="flex h-full w-full items-center justify-center rounded-[1.5rem] bg-white shadow-sm">
+            <motion.span
+              key={imageEmoji}
+              initial={{ opacity: 0, scale: 0.92 }}
+              animate={{ opacity: 1, scale: 1 }}
+              transition={{ duration: 0.25 }}
+              className="text-[7rem] leading-none sm:text-[8rem]"
+              role="img"
+              aria-label={imageLabel}
+            >
+              {imageEmoji}
+            </motion.span>
+          </div>
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-center">
+        <motion.button
+          type="button"
+          onClick={onListen}
+          whileTap={{ scale: 0.97 }}
+          animate={isSpeaking ? { scale: [1, 1.04, 1] } : { scale: 1 }}
+          transition={
+            isSpeaking
+              ? { duration: 0.8, repeat: Infinity, ease: "easeInOut" }
+              : { duration: 0.2 }
+          }
+          className="inline-flex min-h-[60px] items-center justify-center gap-3 rounded-full bg-amber-700 px-8 py-4 text-2xl font-bold text-white shadow-[0_12px_28px_rgba(180,97,16,0.22)] focus-visible:outline-none focus-visible:ring-4 focus-visible:ring-amber-300/70"
+        >
+          <Volume2 className="size-6" aria-hidden="true" />
+          <span>Dengarkan</span>
+        </motion.button>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/data/reading-exercises.ts
+++ b/src/lib/data/reading-exercises.ts
@@ -1,0 +1,63 @@
+export type ReadingExercise = {
+  id: string;
+  words: [string, string];
+  imageEmoji: string;
+  imageLabel: string;
+  question: string;
+  options: [string, string];
+  answer: string;
+  speechText: string;
+};
+
+export const readingExercises: ReadingExercise[] = [
+  {
+    id: "reading-1",
+    words: ["Ini", "bola"],
+    imageEmoji: "⚽",
+    imageLabel: "Bola",
+    question: 'Mana kata "bola"?',
+    options: ["bola", "ini"],
+    answer: "bola",
+    speechText: "Ini bola.",
+  },
+  {
+    id: "reading-2",
+    words: ["Itu", "apel"],
+    imageEmoji: "🍎",
+    imageLabel: "Apel",
+    question: 'Mana kata "apel"?',
+    options: ["apel", "itu"],
+    answer: "apel",
+    speechText: "Itu apel.",
+  },
+  {
+    id: "reading-3",
+    words: ["Ini", "buku"],
+    imageEmoji: "📘",
+    imageLabel: "Buku",
+    question: 'Mana kata "buku"?',
+    options: ["ini", "buku"],
+    answer: "buku",
+    speechText: "Ini buku.",
+  },
+  {
+    id: "reading-4",
+    words: ["Itu", "ikan"],
+    imageEmoji: "🐟",
+    imageLabel: "Ikan",
+    question: 'Mana kata "ikan"?',
+    options: ["ikan", "itu"],
+    answer: "ikan",
+    speechText: "Itu ikan.",
+  },
+  {
+    id: "reading-5",
+    words: ["Ini", "topi"],
+    imageEmoji: "🎩",
+    imageLabel: "Topi",
+    question: 'Mana kata "topi"?',
+    options: ["ini", "topi"],
+    answer: "topi",
+    speechText: "Ini topi.",
+  },
+];


### PR DESCRIPTION
## Summary
- Build responsive reading practice page based on design reference
- Add reading exercise dataset
- Add listen button with Web Speech API
- Add friendly answer selection flow
- Connect completed exercises to local learning state

## Test
- npm run lint
- npm run build

Refs #6