### PR TITLE
fix(reading): resolve auto-advance bug and sync 404 issue

### DIFF
--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,0 +1,67 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  fetchChildProgress,
+  syncLetterComplete,
+  syncReadingComplete,
+  syncStreakBonus,
+  syncAccessibilitySettings,
+  bulkSyncProgress,
+} from "@/lib/supabase/sync";
+
+export async function GET(request: NextRequest) {
+  const childId = request.nextUrl.searchParams.get("childId");
+  if (!childId) {
+    return NextResponse.json({ error: "Missing childId" }, { status: 400 });
+  }
+
+  try {
+    const data = await fetchChildProgress(childId);
+    return NextResponse.json({ data });
+  } catch (error) {
+    console.error("GET /api/sync error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const body = await request.json();
+    const { action, payload } = body;
+
+    if (!action || !payload) {
+      return NextResponse.json({ error: "Missing action or payload" }, { status: 400 });
+    }
+
+    const { childId } = payload;
+    if (!childId) {
+      return NextResponse.json({ error: "Missing childId" }, { status: 400 });
+    }
+
+    let result;
+
+    switch (action) {
+      case "syncLetter":
+        result = await syncLetterComplete(childId, payload.letter);
+        break;
+      case "syncReading":
+        result = await syncReadingComplete(childId, payload.exerciseId, payload.score, payload.level);
+        break;
+      case "syncStreak":
+        result = await syncStreakBonus(childId, payload.streakCount);
+        break;
+      case "syncSettings":
+        result = await syncAccessibilitySettings(childId, payload.settings);
+        break;
+      case "bulkSync":
+        result = await bulkSyncProgress(childId, payload.data);
+        break;
+      default:
+        return NextResponse.json({ error: "Unknown action" }, { status: 400 });
+    }
+
+    return NextResponse.json(result);
+  } catch (error) {
+    console.error("POST /api/sync error:", error);
+    return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
+  }
+}

--- a/src/components/parent/children-management.tsx
+++ b/src/components/parent/children-management.tsx
@@ -114,7 +114,7 @@ export function ChildrenManagement({
     try {
       await createChildProfile(formData);
       setIsAdding(false);
-    } catch (error) {
+    } catch {
       alert("Gagal menambahkan profil anak.");
     } finally {
       setIsPending(false);
@@ -126,7 +126,7 @@ export function ChildrenManagement({
     try {
       await updateChildProfile(id, formData);
       setEditingId(null);
-    } catch (error) {
+    } catch {
       alert("Gagal memperbarui profil anak.");
     } finally {
       setIsPending(false);
@@ -137,7 +137,7 @@ export function ChildrenManagement({
     setIsPending(true);
     try {
       await setActiveChild(id);
-    } catch (error) {
+    } catch {
       alert("Gagal memilih profil aktif.");
     } finally {
       setIsPending(false);
@@ -149,7 +149,7 @@ export function ChildrenManagement({
     setIsPending(true);
     try {
       await deleteChildProfile(id);
-    } catch (error) {
+    } catch {
       alert("Gagal menghapus profil.");
     } finally {
       setIsPending(false);

--- a/src/components/reading/reading-practice.tsx
+++ b/src/components/reading/reading-practice.tsx
@@ -64,6 +64,7 @@ export function ReadingPractice() {
 
   const handleSelectOption = useCallback(
     (option: string) => {
+      setSelectedIndex(currentIndex);
       setSelectedOption(option);
 
       if (option === currentExercise.answer) {
@@ -73,7 +74,7 @@ export function ReadingPractice() {
         setFeedback("incorrect");
       }
     },
-    [completeReadingExercise, currentExercise.answer, currentExercise.id],
+    [completeReadingExercise, currentExercise.answer, currentExercise.id, currentIndex],
   );
 
   const handleRetry = useCallback(() => {

--- a/src/lib/hooks/use-sync-progress.ts
+++ b/src/lib/hooks/use-sync-progress.ts
@@ -1,25 +1,10 @@
 "use client";
 
 import { useCallback, useEffect, useRef } from "react";
-import {
-  fetchChildProgress,
-  syncLetterComplete,
-  syncReadingComplete,
-  syncStreakBonus,
-  syncAccessibilitySettings,
-  bulkSyncProgress,
-} from "@/lib/supabase/sync";
 import type { LearningState, LearningSettings } from "@/lib/store/learning-store";
 
 type SyncStatus = "idle" | "syncing" | "synced" | "error";
 
-/**
- * Hook that handles bidirectional sync between localStorage and Supabase.
- * 
- * - On mount (when activeChildId exists): fetches DB state and merges with local.
- * - Exposes sync functions that can be called after local state mutations.
- * - Gracefully degrades: if no activeChildId or offline, sync is a no-op.
- */
 export function useSyncProgress(
   activeChildId: string | null | undefined,
   localState: LearningState,
@@ -35,13 +20,11 @@ export function useSyncProgress(
   const hasSyncedRef = useRef(false);
   const activeChildIdRef = useRef(activeChildId);
 
-  // Track activeChildId changes
   useEffect(() => {
     activeChildIdRef.current = activeChildId;
     hasSyncedRef.current = false;
   }, [activeChildId]);
 
-  // Initial sync: fetch from DB and merge with local state
   useEffect(() => {
     if (!activeChildId || !isHydrated || hasSyncedRef.current) return;
 
@@ -51,14 +34,15 @@ export function useSyncProgress(
       syncStatusRef.current = "syncing";
 
       try {
-        const dbProgress = await fetchChildProgress(activeChildId!);
+        const response = await fetch(`/api/sync?childId=${activeChildId}`);
+        if (!response.ok) throw new Error("Failed to fetch progress");
+        const { data: dbProgress } = await response.json();
 
         if (cancelled || !dbProgress) {
           syncStatusRef.current = "idle";
           return;
         }
 
-        // Merge strategy: union of local + DB (DB wins for points if higher)
         const mergedLetters = Array.from(
           new Set([
             ...localState.completedLetters,
@@ -82,7 +66,6 @@ export function useSyncProgress(
           name: dbProgress.name || localState.name,
         });
 
-        // If local has data that DB doesn't, push it up
         const localOnlyLetters = localState.completedLetters.filter(
           (l) => !dbProgress.completedLetters.includes(l)
         );
@@ -91,11 +74,21 @@ export function useSyncProgress(
         );
 
         if (localOnlyLetters.length > 0 || localOnlyReadings.length > 0) {
-          await bulkSyncProgress(activeChildId!, {
-            completedLetters: localOnlyLetters,
-            completedReadingIds: localOnlyReadings,
-            points: 0, // Don't double-count points
-            settings: localState.settings as unknown as Record<string, unknown>,
+          await fetch("/api/sync", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              action: "bulkSync",
+              payload: {
+                childId: activeChildId,
+                data: {
+                  completedLetters: localOnlyLetters,
+                  completedReadingIds: localOnlyReadings,
+                  points: 0,
+                  settings: localState.settings as unknown as Record<string, unknown>,
+                },
+              },
+            }),
           });
         }
 
@@ -114,44 +107,20 @@ export function useSyncProgress(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [activeChildId, isHydrated]);
 
-  // Sync individual letter completion
   const syncLetter = useCallback(
     async (letter: string) => {
       const childId = activeChildIdRef.current;
       if (!childId) return;
 
       try {
-        await syncLetterComplete(childId, letter);
-      } catch {
-        // Silently fail — localStorage is the fallback
-      }
-    },
-    []
-  );
-
-  // Sync individual reading exercise completion
-  const syncReading = useCallback(
-    async (exerciseId: string) => {
-      const childId = activeChildIdRef.current;
-      if (!childId) return;
-
-      try {
-        await syncReadingComplete(childId, exerciseId);
-      } catch {
-        // Silently fail — localStorage is the fallback
-      }
-    },
-    []
-  );
-
-  // Sync streak bonus
-  const syncStreak = useCallback(
-    async (streakCount: number) => {
-      const childId = activeChildIdRef.current;
-      if (!childId) return;
-
-      try {
-        await syncStreakBonus(childId, streakCount);
+        await fetch("/api/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "syncLetter",
+            payload: { childId, letter },
+          }),
+        });
       } catch {
         // Silently fail
       }
@@ -159,17 +128,62 @@ export function useSyncProgress(
     []
   );
 
-  // Sync settings update
+  const syncReading = useCallback(
+    async (exerciseId: string) => {
+      const childId = activeChildIdRef.current;
+      if (!childId) return;
+
+      try {
+        await fetch("/api/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "syncReading",
+            payload: { childId, exerciseId },
+          }),
+        });
+      } catch {
+        // Silently fail
+      }
+    },
+    []
+  );
+
+  const syncStreak = useCallback(
+    async (streakCount: number) => {
+      const childId = activeChildIdRef.current;
+      if (!childId) return;
+
+      try {
+        await fetch("/api/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "syncStreak",
+            payload: { childId, streakCount },
+          }),
+        });
+      } catch {
+        // Silently fail
+      }
+    },
+    []
+  );
+
   const syncSettings = useCallback(
     async (settings: Partial<LearningSettings>) => {
       const childId = activeChildIdRef.current;
       if (!childId) return;
 
       try {
-        await syncAccessibilitySettings(
-          childId,
-          settings as Record<string, unknown>
-        );
+        await fetch("/api/sync", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            action: "syncSettings",
+            payload: { childId, settings },
+          }),
+        });
       } catch {
         // Silently fail
       }
@@ -184,3 +198,4 @@ export function useSyncProgress(
     syncSettings,
   };
 }
+

--- a/src/lib/supabase/sync.ts
+++ b/src/lib/supabase/sync.ts
@@ -1,5 +1,3 @@
-"use server";
-
 import { createClient } from "@/lib/supabase/server";
 
 /**


### PR DESCRIPTION
## Summary

Fixes the "jawaban nyangkut" (auto-advance) bug during reading practice and resolves the persistent `POST /letters 404` error caused by Server Actions routing.

## Changes

### Data Model & Actions
- **`src/app/api/sync/route.ts`**: Migrated progress syncing logic from direct Server Actions to an API Route to avoid Next.js routing failures on static-like pages.

### UI Components
- **`src/components/reading/reading-practice.tsx`**: Added `setSelectedIndex(currentIndex)` to lock the question index upon answering, preventing the UI from auto-advancing when the global learning state updates.
- **`src/components/parent/children-management.tsx`**: Fixed linter warnings regarding unused `error` variables in catch blocks.

### State Management
- **`src/lib/hooks/use-sync-progress.ts`**: Switched from calling Server Actions directly to using standard `fetch()` against the new `/api/sync` endpoint, preventing client router hijack upon 404s.

## Verification

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — Build sukses
- [x] `graphify update .` — Knowledge graph updated

Closes #28
